### PR TITLE
パス連結にはURLByAppendingPathComponentを使用するほうが好ましいので改変

### DIFF
--- a/eccube-iOS/WebViewController.m
+++ b/eccube-iOS/WebViewController.m
@@ -18,11 +18,11 @@ static NSString *const kDefaultStartUrl = @"http://example.com";
 - (void)viewDidLoad {
     [super viewDidLoad];
     
-    NSString *urlString = kDefaultStartUrl;
+    NSURL *url = [NSURL URLWithString:kDefaultStartUrl];
     if (self.initialPath != nil){
-        urlString = [NSString stringWithFormat:@"%@%@", urlString, self.initialPath];
+        url = [url URLByAppendingPathComponent:self.initialPath];
     }
-    [self.webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:urlString]]];
+    [self.webView loadRequest:[NSURLRequest requestWithURL:url]];
 }
 
 - (void)didReceiveMemoryWarning {


### PR DESCRIPTION
・stringWithFormatでの連結だと、kDefaultStartUrlの最後に "/" が付与されると生成されるURLの最後が "//" みたいになって正常に動かないことがありますので、パス連結にはURLByAppendingPathComponentを使用するほうが好ましいので改変。

・URLの連結は、文字列としてではなくURLとして連結したほうが良いので改変。
